### PR TITLE
Require Gdk version 3.0

### DIFF
--- a/trough.py
+++ b/trough.py
@@ -19,6 +19,7 @@ import sys
 import signal
 
 import gi
+gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gdk, Gio, GLib, Gtk 
 


### PR DESCRIPTION
Silence warning.

trough.py:23: PyGIWarning: Gdk was imported without specifying a version first. Use gi.require_version('Gdk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk, Gio, GLib, Gtk